### PR TITLE
Handle links with missing http/https in front

### DIFF
--- a/deadseeker.py
+++ b/deadseeker.py
@@ -46,6 +46,8 @@ class LinkParser(HTMLParser):
             print(f'HTTPError: {e.code} - {link}')  # (e.g. 404, 501, etc)
         except urllib.error.URLError as e:
             print(f'URLError: {e.reason} - {link}')  # (e.g. conn. refused)
+        except ValueError as e:
+            print(f'ValueError {e} - {link}')  # ( missing protocol like http )
         # else:
             # print(f'{status} - {link}')
         if self.home in link:


### PR DESCRIPTION
On my page there is the case that there are `src` attributes with missing http/https so an ValueError is raised.
This PR catches that error.